### PR TITLE
tabstop, remove semicolon and other adjustment

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+snippets/**/*
+README.md

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ try {
 ```javascript
 switch (${1:expr}) {
 	case ${2:value}:
-		return $0;
+		break $0;
 	default:
-		return;
+		break;
 }
 ```
 
@@ -239,36 +239,36 @@ function* ${1:name}(${2:arguments}) {
 
 #### `fe⇥` forEach loop
 ```javascript
-${1}.forEach((${2:item}) => {
-	${3}
+forEach((${1:item}) => {
+	${2}
 });${0}
 ```
 
 #### `map⇥` map
 ```javascript
-${1}.map((${2:item}) => {
-	${3}
+map((${1:item}) => {
+	${2}
 })${0}
 ```
 
 #### `reduce⇥` reduce
 ```javascript
-${1}.reduce((${2:previous}, ${3:current}) => {
-	${5}
-}${4:, initial})${0}
+reduce((${1:previous}, ${2:current}) => {
+	${4}
+}${3:, initial})${0}
 ```
 
 #### `filter⇥` filter
 ```javascript
-${1}.filter(${2:item} => {
-	${3}
+filter(${1:item} => {
+	${2}
 })${0}
 ```
 
 #### `find⇥` find
 ```javascript
-${1}.find(${2:item} => {
-	${3}
+find(${1:item} => {
+	${2}
 })${0}
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var ${0}
 
 #### `v=⇥` var assignment
 ```javascript
-var ${1:name} = ${2:value};
+var ${1:name} = ${2:value};${0}
 ```
 
 #### `l⇥` let statement
@@ -32,12 +32,12 @@ let ${0}
 
 #### `l=⇥` let assignment
 ```javascript
-let ${1:name} = ${2:value};
+let ${1:name} = ${2:value};${0}
 ```
 
 #### `dl=⇥` destructuring let assignment
 ```javascript
-let {${1:name}} = ${2:value};
+let {${1:name}} = ${2:value};${0}
 ```
 
 #### `co⇥` const statement
@@ -47,12 +47,12 @@ const ${0}
 
 #### `co=⇥` const assignment
 ```javascript
-const ${1:name} = ${2:value};
+const ${1:name} = ${2:value};${0}
 ```
 
 #### `dco=⇥` destructuring const assignment
 ```javascript
-const {${1:name}} = ${2:value};
+const {${1:name}} = ${2:value};${0}
 ```
 
 ### Flow Control
@@ -240,36 +240,36 @@ function* ${1:name}(${2:arguments}) {
 #### `fe⇥` forEach loop
 ```javascript
 ${1}.forEach((${2:item}) => {
-	${0}
-});
+	${3}
+});${0}
 ```
 
 #### `map⇥` map
 ```javascript
 ${1}.map((${2:item}) => {
-	${0}
-});
+	${3}
+});${0}
 ```
 
 #### `reduce⇥` reduce
 ```javascript
 ${1}.reduce((${2:previous}, ${3:current}) => {
-	${0}
-}${4:, initial});
+	${5}
+}${4:, initial});${0}
 ```
 
 #### `filter⇥` filter
 ```javascript
 ${1}.filter(${2:item} => {
-	${0}
-});
+	${3}
+});${0}
 ```
 
 #### `find⇥` find
 ```javascript
 ${1}.find(${2:item} => {
-	${0}
-});
+	${3}
+});${0}
 ```
 
 ### Objects and Classes
@@ -428,22 +428,22 @@ ${1:promise}.catch((${2:err}) => {
 ### ES6 Modules
 #### `ex⇥` export (ES6)
 ```javascript
-export ${1:member};
+export ${1:member};${0}
 ```
 
 #### `exd⇥` export default (ES6)
 ```javascript
-export default ${1:member};
+export default ${1:member};${0}
 ```
 
 #### `im⇥` import module (ES6)
 ```javascript
-import ${1:*} from '${2:module}';
+import ${2:*} from '${1:module}';${0}
 ```
 
 #### `ima⇥` import module as (ES6)
 ```javascript
-import ${1:*} as ${2:name} from '${3:module}';
+import ${2:*} as ${3:name} from '${1:module}';${0}
 ```
 
 ### Node.js
@@ -454,49 +454,49 @@ import ${1:*} as ${2:name} from '${3:module}';
 
 #### `re⇥` require
 ```javascript
-require('${1:module}');
+require('${1:module}');${0}
 ```
 
 #### `rel⇥` require local
 ```javascript
-require('./${1:module}');
+require('./${1:module}');${0}
 ```
 
 #### `req⇥` require assignment
 ```javascript
-const ${1:module} = require('${1:module}');
+const ${2:module} = require('${1:module}');${0}
 ```
 
 #### `reql⇥` require assignment local
 ```javascript
-const ${1:module} = require('./${1:module}');
+const ${2:module} = require('./${1:module}');${0}
 ```
 
 #### `dreq⇥` destructuring require assignment
 ```javascript
-const {${1:module}} = require('${1:module}');
+const {${2:module}} = require('${1:module}');${0}
 ```
 
 #### `dreql⇥` destructuring require assignment local
 ```javascript
-const {${1:module}} = require('./${1:module}');
+const {${2:module}} = require('./${1:module}');${0}
 ```
 
 #### `em⇥` exports.member
 ```javascript
-exports.${1:member} = ${2:value};
+exports.${1:member} = ${2:value};${0}
 ```
 
 #### `me⇥` module.exports
 ```javascript
-module.exports = ${1:name};
+module.exports = ${1:name};${0}
 ```
 
 #### `meo⇥` module exports object
 ```javascript
 module.exports = {
 	${1:member}
-};
+};${0}
 ```
 
 #### `on⇥` event handler
@@ -574,54 +574,54 @@ afterEach(() => {
 ### Console
 #### `cl⇥` console.log
 ```javascript
-console.log(${0});
+console.log(${1});${0}
 ```
 
 #### `ce⇥` console.error
 ```javascript
-console.error(${0});
+console.error(${1});${0}
 ```
 
 #### `cw⇥` console.warn
 ```javascript
-console.warn(${0});
+console.warn(${1});${0}
 ```
 
 #### `cll⇥` console.log labeled
 ```javascript
-console.log('${0}', ${0});
+console.log('${1}', ${1});${0}
 ```
 
 #### `cel⇥` console.error labeled
 ```javascript
-console.error('${0}', ${0});
+console.error('${1}', ${1});${0}
 ```
 
 #### `cwl⇥` console.warn labeled
 ```javascript
-console.warn('${0}', ${0});
+console.warn('${1}', ${1});${0}
 ```
 
 ### Timers
 #### `st⇥` setTimeout
 ```javascript
-setTimeout(() => {
+setTimeout((${2}) => {
 	${0}
 }, ${1:delay});
 ```
 
 #### `si⇥` setInterval
 ```javascript
-setInterval(() => {
+setInterval((${2}) => {
 	${0}
 }, ${1:delay});
 ```
 
 #### `sim⇥` setImmediate
 ```javascript
-setImmediate(() => {
+setImmediate((${2}) => {
 	${0}
-});
+}${1});
 ```
 
 #### `nt⇥` process nextTick

--- a/README.md
+++ b/README.md
@@ -248,28 +248,28 @@ ${1}.forEach((${2:item}) => {
 ```javascript
 ${1}.map((${2:item}) => {
 	${3}
-});${0}
+})${0}
 ```
 
 #### `reduce⇥` reduce
 ```javascript
 ${1}.reduce((${2:previous}, ${3:current}) => {
 	${5}
-}${4:, initial});${0}
+}${4:, initial})${0}
 ```
 
 #### `filter⇥` filter
 ```javascript
 ${1}.filter(${2:item} => {
 	${3}
-});${0}
+})${0}
 ```
 
 #### `find⇥` find
 ```javascript
 ${1}.find(${2:item} => {
 	${3}
-});${0}
+})${0}
 ```
 
 ### Objects and Classes
@@ -277,12 +277,12 @@ ${1}.find(${2:item} => {
 ```javascript
 {
 	kv${0}
-};
+}
 ```
 
 #### `slol⇥` same-line object literal
 ```javascript
-{ kv${0} };
+{ kv${0} }
 ```
 
 #### `kv⇥` key/value pair
@@ -428,12 +428,12 @@ ${1:promise}.catch((${2:err}) => {
 ### ES6 Modules
 #### `ex⇥` export (ES6)
 ```javascript
-export ${1:member};${0}
+export ${1:member}${0}
 ```
 
 #### `exd⇥` export default (ES6)
 ```javascript
-export default ${1:member};${0}
+export default ${1:member}${0}
 ```
 
 #### `im⇥` import module (ES6)
@@ -574,32 +574,32 @@ afterEach(() => {
 ### Console
 #### `cl⇥` console.log
 ```javascript
-console.log(${1});${0}
+console.log(${1})${0}
 ```
 
 #### `ce⇥` console.error
 ```javascript
-console.error(${1});${0}
+console.error(${1})${0}
 ```
 
 #### `cw⇥` console.warn
 ```javascript
-console.warn(${1});${0}
+console.warn(${1})${0}
 ```
 
 #### `cll⇥` console.log labeled
 ```javascript
-console.log('${1}', ${1});${0}
+console.log('${1}', ${1})${0}
 ```
 
 #### `cel⇥` console.error labeled
 ```javascript
-console.error('${1}', ${1});${0}
+console.error('${1}', ${1})${0}
 ```
 
 #### `cwl⇥` console.warn labeled
 ```javascript
-console.warn('${1}', ${1});${0}
+console.warn('${1}', ${1})${0}
 ```
 
 ### Timers

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -108,7 +108,7 @@
     },
     "switch case": {
         "prefix": "sw",
-        "body": "switch (${1:expr}) {\n\tcase ${2:value}:\n\t\treturn $0;\n\tdefault:\n\t\treturn;\n}",
+        "body": "switch (${1:expr}) {\n\tcase ${2:value}:\n\t\tbreak $0;\n\tdefault:\n\t\tbreak;\n}",
         "description": "switch case"
     },
     // Functions
@@ -170,27 +170,27 @@
     },
     "forEach loop": {
         "prefix": "fe",
-        "body": "${1}.forEach((${2:item}) => {\n\t${3}\n});${0}",
+        "body": "forEach((${1:item}) => {\n\t${2}\n});${0}",
         "description": "forEach loop"
     },
     "map": {
         "prefix": "map",
-        "body": "${1}.map((${2:item}) => {\n\t${3}\n})${0}",
+        "body": "map((${1:item}) => {\n\t${2}\n})${0}",
         "description": "map"
     },
     "reduce": {
         "prefix": "reduce",
-        "body": "${1}.reduce((${2:previous}, ${3:current}) => {\n\t${5}\n}${4:, initial})${0}",
+        "body": "reduce((${1:previous}, ${2:current}) => {\n\t${4}\n}${3:, initial})${0}",
         "description": "reduce"
     },
     "filter": {
         "prefix": "filter",
-        "body": "${1}.filter(${2:item} => {\n\t${3}\n})${0}",
+        "body": "filter(${1:item} => {\n\t${2}\n})${0}",
         "description": "filter"
     },
     "find": {
         "prefix": "find",
-        "body": "${1}.find(${2:item} => {\n\t${3}\n})${0}",
+        "body": "find(${1:item} => {\n\t${2}\n})${0}",
         "description": "find"
     },
     // Objects and Classes
@@ -299,12 +299,12 @@
     },
     "Promise.then": {
         "prefix": "then",
-        "body": "${1:promise}.then((${2:value}) => {\n\t${0}\n})",
+        "body": "then((${1:value}) => {\n\t${0}\n})",
         "description": "Promise.then"
     },
     "Promise.catch": {
         "prefix": "catch",
-        "body": "${1:promise}.catch((${2:err}) => {\n\t${0}\n})",
+        "body": "catch((${1:err}) => {\n\t${0}\n})",
         "description": "Promise.catch"
     },
     // ES6 Modules

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -175,33 +175,33 @@
     },
     "map": {
         "prefix": "map",
-        "body": "${1}.map((${2:item}) => {\n\t${3}\n});${0}",
+        "body": "${1}.map((${2:item}) => {\n\t${3}\n})${0}",
         "description": "map"
     },
     "reduce": {
         "prefix": "reduce",
-        "body": "${1}.reduce((${2:previous}, ${3:current}) => {\n\t${5}\n}${4:, initial});${0}",
+        "body": "${1}.reduce((${2:previous}, ${3:current}) => {\n\t${5}\n}${4:, initial})${0}",
         "description": "reduce"
     },
     "filter": {
         "prefix": "filter",
-        "body": "${1}.filter(${2:item} => {\n\t${3}\n});${0}",
+        "body": "${1}.filter(${2:item} => {\n\t${3}\n})${0}",
         "description": "filter"
     },
     "find": {
         "prefix": "find",
-        "body": "${1}.find(${2:item} => {\n\t${3}\n});${0}",
+        "body": "${1}.find(${2:item} => {\n\t${3}\n})${0}",
         "description": "find"
     },
     // Objects and Classes
     "object literal": {
         "prefix": "ol",
-        "body": "{\n\tkv${0}\n};",
+        "body": "{\n\tkv${0}\n}${0}",
         "description": "object literal"
     },
     "same-line object literal": {
         "prefix": "slol",
-        "body": "{ kv${0} };",
+        "body": "{ kv${0} }${0}",
         "description": "same-line object literal"
     },
     "key/value pair": {
@@ -310,12 +310,12 @@
     // ES6 Modules
     "export (ES6)": {
         "prefix": "ex",
-        "body": "export ${1:member};${0}",
+        "body": "export ${1:member}${0}",
         "description": "export (ES6)"
     },
     "export default (ES6)": {
         "prefix": "exd",
-        "body": "export default ${1:member};${0}",
+        "body": "export default ${1:member}${0}",
         "description": "export default (ES6)"
     },
     "import module (ES6)": {
@@ -433,32 +433,32 @@
     // Console
     "console.log": {
         "prefix": "cl",
-        "body": "console.log(${1});${0}",
+        "body": "console.log(${1})${0}",
         "description": "console.log"
     },
     "console.error": {
         "prefix": "ce",
-        "body": "console.error(${1});${0}",
+        "body": "console.error(${1})${0}",
         "description": "console.error"
     },
     "console.warn": {
         "prefix": "cw",
-        "body": "console.warn(${1});${0}",
+        "body": "console.warn(${1})${0}",
         "description": "console.warn"
     },
     "console.log labeled": {
         "prefix": "cll",
-        "body": "console.log('${1}', ${1});${0}",
+        "body": "console.log('${1}', ${1})${0}",
         "description": "console.log labeled"
     },
     "console.error labeled": {
         "prefix": "cel",
-        "body": "console.error('${1}', ${1});${0}",
+        "body": "console.error('${1}', ${1})${0}",
         "description": "console.error labeled"
     },
     "console.warn labeled": {
         "prefix": "cwl",
-        "body": "console.warn('${1}', ${1});${0}",
+        "body": "console.warn('${1}', ${1})${0}",
         "description": "console.warn labeled"
     },
     // Timers

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -7,7 +7,7 @@
     },
     "var assignment": {
         "prefix": "v=",
-        "body": "var ${1:name} = ${2:value};",
+        "body": "var ${1:name} = ${2:value};${0}",
         "description": "var assignment"
     },
     "let statement": {
@@ -17,12 +17,12 @@
     },
     "let assignment": {
         "prefix": "l=",
-        "body": "let ${1:name} = ${2:value};",
+        "body": "let ${1:name} = ${2:value};${0}",
         "description": "let assignment"
     },
     "destructuring let assignment": {
         "prefix": "dl=",
-        "body": "let {${1:name}} = ${2:value};",
+        "body": "let {${1:name}} = ${2:value};${0}",
         "description": "destructuring let assignment"
     },
     "const statement": {
@@ -32,12 +32,12 @@
     },
     "const assignment": {
         "prefix": "co=",
-        "body": "const ${1:name} = ${2:value};",
+        "body": "const ${1:name} = ${2:value};${0}",
         "description": "const assignment"
     },
     "destructuring const assignment": {
         "prefix": "dco=",
-        "body": "const {${1:name}} = ${2:value};",
+        "body": "const {${1:name}} = ${2:value};${0}",
         "description": "destructuring const assignment"
     },
     // Flow Control
@@ -170,27 +170,27 @@
     },
     "forEach loop": {
         "prefix": "fe",
-        "body": "${1}.forEach((${2:item}) => {\n\t${0}\n});",
+        "body": "${1}.forEach((${2:item}) => {\n\t${3}\n});${0}",
         "description": "forEach loop"
     },
     "map": {
         "prefix": "map",
-        "body": "${1}.map((${2:item}) => {\n\t${0}\n});",
+        "body": "${1}.map((${2:item}) => {\n\t${3}\n});${0}",
         "description": "map"
     },
     "reduce": {
         "prefix": "reduce",
-        "body": "${1}.reduce((${2:previous}, ${3:current}) => {\n\t${0}\n}${4:, initial});",
+        "body": "${1}.reduce((${2:previous}, ${3:current}) => {\n\t${5}\n}${4:, initial});${0}",
         "description": "reduce"
     },
     "filter": {
         "prefix": "filter",
-        "body": "${1}.filter(${2:item} => {\n\t${0}\n});",
+        "body": "${1}.filter(${2:item} => {\n\t${3}\n});${0}",
         "description": "filter"
     },
     "find": {
         "prefix": "find",
-        "body": "${1}.find(${2:item} => {\n\t${0}\n});",
+        "body": "${1}.find(${2:item} => {\n\t${3}\n});${0}",
         "description": "find"
     },
     // Objects and Classes
@@ -310,22 +310,22 @@
     // ES6 Modules
     "export (ES6)": {
         "prefix": "ex",
-        "body": "export ${1:member};",
+        "body": "export ${1:member};${0}",
         "description": "export (ES6)"
     },
     "export default (ES6)": {
         "prefix": "exd",
-        "body": "export default ${1:member};",
+        "body": "export default ${1:member};${0}",
         "description": "export default (ES6)"
     },
     "import module (ES6)": {
         "prefix": "im",
-        "body": "import ${1:*} from '${2:module}';",
+        "body": "import ${2:*} from '${1:module}';${0}",
         "description": "import module (ES6)"
     },
     "import module as (ES6)": {
         "prefix": "ima",
-        "body": "import ${1:*} as ${2:name} from '${3:module}';",
+        "body": "import ${2:*} as ${3:name} from '${1:module}';${0}",
         "description": "import module as (ES6)"
     },
     // Node.js
@@ -336,47 +336,47 @@
     },
     "require": {
         "prefix": "re",
-        "body": "require('${1:module}');",
+        "body": "require('${1:module}');${0}",
         "description": "require"
     },
     "require local": {
         "prefix": "rel",
-        "body": "require('./${1:module}');",
+        "body": "require('./${1:module}');${0}",
         "description": "require local"
     },
     "require assignment": {
         "prefix": "req",
-        "body": "const ${1:module} = require('${1:module}');",
+        "body": "const ${2:module} = require('${1:module}');${0}",
         "description": "require assignment"
     },
     "require assignment local": {
         "prefix": "reql",
-        "body": "const ${1:module} = require('./${1:module}');",
+        "body": "const ${2:module} = require('./${1:module}');${0}",
         "description": "require assignment local"
     },
     "destructuring require assignment": {
         "prefix": "dreq",
-        "body": "const {${1:module}} = require('${1:module}');",
+        "body": "const {${2:module}} = require('${1:module}');${0}",
         "description": "destructuring require assignment"
     },
     "destructuring require assignment local": {
         "prefix": "dreql",
-        "body": "const {${1:module}} = require('./${1:module}');",
+        "body": "const {${2:module}} = require('./${1:module}');${0}",
         "description": "destructuring require assignment local"
     },
     "exports.member": {
         "prefix": "em",
-        "body": "exports.${1:member} = ${2:value};",
+        "body": "exports.${1:member} = ${2:value};${0}",
         "description": "exports.member"
     },
     "module.exports": {
         "prefix": "me",
-        "body": "module.exports = ${1:name};",
+        "body": "module.exports = ${1:name};${0}",
         "description": "module.exports"
     },
     "module exports object": {
         "prefix": "meo",
-        "body": "module.exports = {\n\t${1:member}\n};",
+        "body": "module.exports = {\n\t${1:member}\n};${0}",
         "description": "module exports object"
     },
     "event handler": {
@@ -433,48 +433,48 @@
     // Console
     "console.log": {
         "prefix": "cl",
-        "body": "console.log(${0});",
+        "body": "console.log(${1});${0}",
         "description": "console.log"
     },
     "console.error": {
         "prefix": "ce",
-        "body": "console.error(${0});",
+        "body": "console.error(${1});${0}",
         "description": "console.error"
     },
     "console.warn": {
         "prefix": "cw",
-        "body": "console.warn(${0});",
+        "body": "console.warn(${1});${0}",
         "description": "console.warn"
     },
     "console.log labeled": {
         "prefix": "cll",
-        "body": "console.log('${0}', ${0});",
+        "body": "console.log('${1}', ${1});${0}",
         "description": "console.log labeled"
     },
     "console.error labeled": {
         "prefix": "cel",
-        "body": "console.error('${0}', ${0});",
+        "body": "console.error('${1}', ${1});${0}",
         "description": "console.error labeled"
     },
     "console.warn labeled": {
         "prefix": "cwl",
-        "body": "console.warn('${0}', ${0});",
+        "body": "console.warn('${1}', ${1});${0}",
         "description": "console.warn labeled"
     },
     // Timers
     "setTimeout": {
         "prefix": "st",
-        "body": "setTimeout(() => {\n\t${0}\n}, ${1:delay});",
+        "body": "setTimeout((${2}) => {\n\t${0}\n}, ${1:delay});",
         "description": "setTimeout"
     },
     "setInterval": {
         "prefix": "si",
-        "body": "setInterval(() => {\n\t${0}\n}, ${1:delay});",
+        "body": "setInterval((${2}) => {\n\t${0}\n}, ${1:delay});",
         "description": "setInterval"
     },
     "setImmediate": {
         "prefix": "sim",
-        "body": "setImmediate(() => {\n\t${0}\n});",
+        "body": "setImmediate((${2}) => {\n\t${0}\n}${1});",
         "description": "setImmediate"
     },
     "process nextTick": {


### PR DESCRIPTION
1. Adjust tabstop for better experience
  * Declarations
  * Iterables
  * ES6 Modules: for intellisense
  * Node.js: for make same behavior with ES6 Modules
  * Console: ${0} at the end of snippet
  * Timer: add tabstop for possibly parameter
2. Remove unnecessary semicolon due to snippet possibly as argument or declaration that need no semicolon
  * Iterables
  * Objects and Classes
  * ES6 Modules
  * Console
3. Other
  * return -> break is more common in switch condition
  * remove Arrray and Promise object and dot for better experience for chaining style